### PR TITLE
Ignore unrecognized fields in MetaData

### DIFF
--- a/discovery-client/src/main/java/com/comcast/tvx/cloud/MetaData.java
+++ b/discovery-client/src/main/java/com/comcast/tvx/cloud/MetaData.java
@@ -21,10 +21,12 @@ import java.util.UUID;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 /**
  * The Class WorkerMetadata.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonRootName("Worker")
 public final class MetaData {
 


### PR DESCRIPTION
We will often write additional properties along with the MetaData into Zookeeper.  Ideally we would like to prevent the JSON parser from throwing exceptions when we parse those objects.  
