### PR TITLE
Feature/increase error help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings/
 target/
 
+.idea/
+*.iml

--- a/discovery-client/src/main/java/com/comcast/tvx/cloud/RegistrationMain.java
+++ b/discovery-client/src/main/java/com/comcast/tvx/cloud/RegistrationMain.java
@@ -39,7 +39,7 @@ public class RegistrationMain {
     @Argument(alias = "i", description = "IP of service to register", required = true)
     private static String ip = null;
 
-    @Argument(alias = "s", description = "Comma seperated list of services to register (e.g. \"http:80,https:443\")", required = true)
+    @Argument(alias = "s", description = "Comma separated list of services to register (e.g. \"http:80,https:443\")", required = true)
     private static String serviceSpec = null;
 
     @Argument(alias = "f", description = "Flavor of deployed application.", required = false)
@@ -69,6 +69,7 @@ public class RegistrationMain {
         try {
             Args.parse(RegistrationMain.class, args);
         } catch (IllegalArgumentException e) {
+            log.error("Illegal Arguments provided", e);
             Args.usage(RegistrationMain.class);
             System.exit(1);
 

--- a/reagent/src/main/rpmroot/bin/reagent.sh
+++ b/reagent/src/main/rpmroot/bin/reagent.sh
@@ -9,24 +9,49 @@ CONF_DIR=$APP_HOME/conf
 RUN_DIR=/var/run/$NAME
 LOG_DIR=/var/log/$NAME
 
+build_params=""
+
 # source properties via facter if not defined
 if [ -z "$zookeeper_connection" ]; then
     zookeeper_connection=`facter zookeeper_connection`
 fi
+if [ -n "$zookeeper_connection" ]; then
+    build_params="$build_params -z $zookeeper_connection"
+fi
+
 if [ -z "$ipaddress" ]; then
     ipaddress=`facter ipaddress`
 fi
+if [ -n "$ipaddress" ]; then
+    build_params="$build_params -i $ipaddress"
+fi
+
 if [ -z "$service_spec" ]; then
     service_spec=`facter service_spec`
 fi
+if [ -n "$service_spec" ]; then
+    build_params="$build_params -s $service_spec"
+fi
+
 if [ -z "$flavor" ]; then
     flavor=`facter flavor`
 fi
+if [ -n "$flavor" ]; then
+    build_params="$build_params -f $flavor"
+fi
+
 if [ -z "$region" ]; then
     region=`facter region`
 fi
+if [ -n "$region" ]; then
+    build_params="$build_params -r $region"
+fi
+
 if [ -z "$availability_zone" ]; then
     availability_zone=`facter availability_zone`
+fi
+if [ -n "$availability_zone" ]; then
+    build_params="$build_params -a $availability_zone"
 fi
 
 # If JAVA_OPTS are set, then it will completely override defaults.
@@ -38,7 +63,7 @@ if [ "$1" != "--nodaemon" ]; then
     nohup java $JAVA_OPTS \
         -cp $CONF_DIR:$APP_HOME/lib/* \
         com.comcast.tvx.cloud.RegistrationMain \
-        -z $zookeeper_connection -i $ipaddress -s $service_spec -f $flavor -r $region -a $availability_zone \
+        $build_params \
         > $LOG_DIR/$NAME.out 2>&1 &
 
     echo $! > $RUN_DIR/$NAME.pid
@@ -47,6 +72,6 @@ else
     java $JAVA_OPTS \
         -cp $CONF_DIR:$APP_HOME/lib/* \
         com.comcast.tvx.cloud.RegistrationMain \
-        -z $zookeeper_connection -i $ipaddress -s $service_spec -f $flavor -r $region -a $availability_zone
+        $build_params
 
 fi


### PR DESCRIPTION
I found that the defaults of the client were never used because the shell script would always supply an empty argument.

Example:
If region was not defined (in env or facter), the result would be
```
region=`facter region` # == ""
...
nohup java ... -f flavor -r -a zone1
```

The arg parser in java didn't care for `-r -a` as -r is not a boolean type.

